### PR TITLE
Upgrade frontend template to synapse-common 0.3.0

### DIFF
--- a/application/client/oauth.js
+++ b/application/client/oauth.js
@@ -56,11 +56,11 @@ var OAuthClient = HttpGateway.extend({
         );
     },
 
-    _getRequestOptions : function(method, path)
+    getRequestOptions : function(method, path)
     {
         var options;
 
-        options = HttpGateway.prototype._getRequestOptions.call(this, method, path);
+        options = HttpGateway.prototype.getRequestOptions.call(this, method, path);
 
         options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
 

--- a/application/client/user.js
+++ b/application/client/user.js
@@ -23,11 +23,11 @@ var UserClient = HttpGateway.extend({
         this.token = tokenData;
     },
 
-    _getRequestOptions : function(method, path)
+    getRequestOptions : function(method, path)
     {
         var options, token;
 
-        options = HttpGateway.prototype._getRequestOptions.call(this, method, path);
+        options = HttpGateway.prototype.getRequestOptions.call(this, method, path);
 
         token = this.token || store.get('token');
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react"           : "0.12.1",
     "react-router"    : "0.11.4",
     "store"           : "1.3.16",
-    "synapse-common"  : "0.2.0",
+    "synapse-common"  : "0.3.0",
     "synfrastructure" : "git://github.com/synapsestudios/synfrastructure.git#master",
     "underscore"      : "1.6.0"
   }


### PR DESCRIPTION
## Upgrade to synapse-common 0.3.0

### Acceptance Criteria
1. OAuth and User clients override `_getRequestOptions` instead of `getRequestOptions` causing logins to fail.

### Tasks
- Modify clients

### Additional Notes
- Related to synapsestudios/synapse-common#29 and synapsestudios/synapse-common#31.