### PR TITLE
Initialize script tries to edit globals.js file that no longer exists

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -70,7 +70,6 @@ if [[ $confirm =~ ^[yY] ]]; then
 
   echo "Updating config files"
   sed -i "" s/%DEV_API_HOST%/$dev_api_host/g "./application/config/development.js"
-  sed -i "" s/%DEV_API_HOST%/$dev_api_host/g "./__tests__/globals.js"
   sed -i "" s/%QA_API_HOST%/$qa_api_host/g "./application/config/qa.js"
   sed -i "" s/%PRODUCTION_API_HOST%/$production_api_host/g "./application/config/production.js"
 


### PR DESCRIPTION
## Description
The initialize script is looking for a globals.js file that no longer exists. Remove the line.

## Details
__tests__/globals.js was removed in #69 
https://github.com/synapsestudios/frontend-template/blob/master/initialize.sh#L73