### PR TITLE
Error when running npm start: unbound variable $font-weight-normal

### DIFF
--- a/application/ui/components/pattern-library/sections/pl-callouts-prompts.jsx
+++ b/application/ui/components/pattern-library/sections/pl-callouts-prompts.jsx
@@ -41,16 +41,16 @@ module.exports = React.createClass({
                     <div className='row'>
                         <div className="small-12">
 
-                            <Alert message='This is an alert inidicating an alert' alertType='alert'>
+                            <Alert message='This is an alert indicating an alert' alertType='alert'>
                             </Alert>
 
-                            <Alert message='This is an alert inidicating information' alertType='info'>
+                            <Alert message='This is an alert indicating information' alertType='info'>
                             </Alert>
 
-                            <Alert message='This is an alert inidicating a warning' alertType='warning'>
+                            <Alert message='This is an alert indicating a warning' alertType='warning'>
                             </Alert>
 
-                            <Alert message='This is an alert inidicating a success' alertType='success'>
+                            <Alert message='This is an alert indicating a success' alertType='success'>
                             </Alert>
 
                         </div>

--- a/application/ui/scss/components/callouts-prompts/_alerts.scss
+++ b/application/ui/scss/components/callouts-prompts/_alerts.scss
@@ -19,7 +19,7 @@ $alert-padding-opposite-direction : $alert-padding-top + rem-calc(10) !default;
 $alert-padding-bottom             : $alert-padding-top !default;
 
 // We use these to control text style.
-$alert-font-weight    : $font-weight-normal !default;
+$alert-font-weight    : normal !default;
 $alert-font-size      : rem-calc(13) !default;
 $alert-font-color     : $white !default;
 $alert-font-color-alt : scale-color($secondary-color, $lightness: -66%) !default;


### PR DESCRIPTION
## Description
Error when running npm start:
```
ERROR in ./~/css-loader!./~/autoprefixer-loader!./~/sass-loader?outputStyle=nested&includePaths[]=/Users/synapse/Documents/Github/frontend-template/node_modules!./application/ui/scss/app.scss
Module build failed: unbound variable $font-weight-normal (22:25)
 @ ./application/ui/scss/app.scss 4:14-461 12:19-466
```
Also fixing a typo "inidicating" on alerts

