### PR TITLE
Pattern Library Grid doesn't look good in large browser windows

### DIFF
--- a/application/ui/components/pattern-library/sections/pl-grid.jsx
+++ b/application/ui/components/pattern-library/sections/pl-grid.jsx
@@ -10,72 +10,72 @@ module.exports = React.createClass ({
     render : function()
     {
         return (
-          <div className='pl-page example'>
-          <h1 className='pl-h1'>Grid</h1>
-            <div className="row">.row</div>
-            <div className="row">
-            <div className="large-2 columns">.large-2</div>
-            <div className="large-10 columns">.large-10.columns</div>
+            <div className='pl-page example'>
+                <h1 className='pl-h1'>Grid</h1>
+                <div className="row">.row</div>
+                <div className="row">
+                    <div className="large-2 columns">.large-2</div>
+                    <div className="large-10 columns">.large-10.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-3 columns">.large-3.columns</div>
+                    <div className="large-9 columns">.large-9.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-4 columns">.large-4.columns</div>
+                    <div className="large-8 columns">.large-8.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-5 columns">.large-5.columns</div>
+                    <div className="large-7 columns">.large-7.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-6 columns">.large-6.columns</div>
+                    <div className="large-6 columns">.large-6.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-7 columns">.large-7.columns</div>
+                    <div className="large-5 columns">.large-5.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-8 columns">.large-8.columns</div>
+                    <div className="large-4 columns">.large-4.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-9 columns">.large-9.columns</div>
+                    <div className="large-3 columns">.large-3.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-10 columns">.large-10.columns</div>
+                    <div className="large-2 columns">.large-2</div>
+                </div>
+                <div className="row">
+                    <div className="large-12 columns">.large-12.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-6 columns">.large-6.columns</div>
+                    <div className="large-6 columns">.large-6.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-4 columns">.large-4.columns</div>
+                    <div className="large-4 columns">.large-4.columns</div>
+                    <div className="large-4 columns">.large-4.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-3 columns">.large-3.columns</div>
+                    <div className="large-3 columns">.large-3.columns</div>
+                    <div className="large-3 columns">.large-3.columns</div>
+                    <div className="large-3 columns">.large-3.columns</div>
+                </div>
+                <div className="row">
+                    <div className="large-2 columns">.large-2.columns</div>
+                    <div className="large-2 columns">.large-2.columns</div>
+                    <div className="large-2 columns">.large-2.columns</div>
+                    <div className="large-2 columns">.large-2.columns</div>
+                    <div className="large-2 columns">.large-2.columns</div>
+                    <div className="large-2 columns">.large-2.columns</div>
+                </div>
             </div>
-            <div className="row">
-            <div className="large-3 columns">.large-3.columns</div>
-            <div className="large-9 columns">.large-9.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-4 columns">.large-4.columns</div>
-            <div className="large-8 columns">.large-8.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-5 columns">.large-5.columns</div>
-            <div className="large-7 columns">.large-7.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-6 columns">.large-6.columns</div>
-            <div className="large-6 columns">.large-6.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-7 columns">.large-7.columns</div>
-            <div className="large-5 columns">.large-5.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-8 columns">.large-8.columns</div>
-            <div className="large-4 columns">.large-4.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-9 columns">.large-9.columns</div>
-            <div className="large-3 columns">.large-3.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-10 columns">.large-10.columns</div>
-            <div className="large-2 columns">.large-2</div>
-            </div>
-            <div className="row">
-            <div className="large-12 columns">.large-12.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-6 columns">.large-6.columns</div>
-            <div className="large-6 columns">.large-6.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-4 columns">.large-4.columns</div>
-            <div className="large-4 columns">.large-4.columns</div>
-            <div className="large-4 columns">.large-4.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-3 columns">.large-3.columns</div>
-            <div className="large-3 columns">.large-3.columns</div>
-            <div className="large-3 columns">.large-3.columns</div>
-            <div className="large-3 columns">.large-3.columns</div>
-            </div>
-            <div className="row">
-            <div className="large-2 columns">.large-2.columns</div>
-            <div className="large-2 columns">.large-2.columns</div>
-            <div className="large-2 columns">.large-2.columns</div>
-            <div className="large-2 columns">.large-2.columns</div>
-            <div className="large-2 columns">.large-2.columns</div>
-            <div className="large-2 columns">.large-2.columns</div>
-            </div>
-        </div>
         );
     }
 });

--- a/application/ui/components/pattern-library/sections/pl-grid.jsx
+++ b/application/ui/components/pattern-library/sections/pl-grid.jsx
@@ -10,40 +10,72 @@ module.exports = React.createClass ({
     render : function()
     {
         return (
-        <div className='pl-page'>
+          <div className='pl-page example'>
           <h1 className='pl-h1'>Grid</h1>
-            <div className="row display">
-              <div className="small-2 large-4 columns"><span className="hide-for-large">2</span><span className="show-for-large">4</span></div>
-              <div className="small-4 large-4 columns">4</div>
-              <div className="small-6 large-4 columns"><span className="hide-for-large">6</span><span className="show-for-large">4</span></div>
+            <div className="row">.row</div>
+            <div className="row">
+            <div className="large-2 columns">.large-2</div>
+            <div className="large-10 columns">.large-10.columns</div>
             </div>
-            <div className="row display">
-              <div className="large-3 columns"><span className="hide-for-large">full</span><span className="show-for-large">3</span></div>
-              <div className="large-6 columns"><span className="hide-for-large">full</span><span className="show-for-large">6</span></div>
-              <div className="large-3 columns"><span className="hide-for-large">full</span><span className="show-for-large">3</span></div>
+            <div className="row">
+            <div className="large-3 columns">.large-3.columns</div>
+            <div className="large-9 columns">.large-9.columns</div>
             </div>
-            <div className="row display">
-              <div className="small-6 large-2 columns"><span className="hide-for-large">6</span><span className="show-for-large">2</span></div>
-              <div className="small-6 large-8 columns"><span className="hide-for-large">6</span><span className="show-for-large">8</span></div>
-              <div className="small-12 large-2 columns"><span className="hide-for-large">full</span><span className="show-for-large">2</span></div>
+            <div className="row">
+            <div className="large-4 columns">.large-4.columns</div>
+            <div className="large-8 columns">.large-8.columns</div>
             </div>
-            <div className="row display">
-              <div className="small-3 columns">3</div>
-              <div className="small-9 columns">9</div>
+            <div className="row">
+            <div className="large-5 columns">.large-5.columns</div>
+            <div className="large-7 columns">.large-7.columns</div>
             </div>
-            <div className="row display">
-              <div className="large-4 columns"><span className="hide-for-large">full</span><span className="show-for-large">4</span></div>
-              <div className="large-8 columns"><span className="hide-for-large">full</span><span className="show-for-large">8</span></div>
+            <div className="row">
+            <div className="large-6 columns">.large-6.columns</div>
+            <div className="large-6 columns">.large-6.columns</div>
             </div>
-            <div className="row display">
-              <div className="small-6 large-5 columns"><span className="hide-for-large">6</span><span className="show-for-large">5</span></div>
-              <div className="small-6 large-7 columns"><span className="hide-for-large">6</span><span className="show-for-large">7</span></div>
+            <div className="row">
+            <div className="large-7 columns">.large-7.columns</div>
+            <div className="large-5 columns">.large-5.columns</div>
             </div>
-            <div className="row display">
-              <div className="large-6 columns"><span className="hide-for-large">full</span><span className="show-for-large">6</span></div>
-              <div className="large-6 columns"><span className="hide-for-large">full</span><span className="show-for-large">6</span></div>
+            <div className="row">
+            <div className="large-8 columns">.large-8.columns</div>
+            <div className="large-4 columns">.large-4.columns</div>
             </div>
-          </div>
+            <div className="row">
+            <div className="large-9 columns">.large-9.columns</div>
+            <div className="large-3 columns">.large-3.columns</div>
+            </div>
+            <div className="row">
+            <div className="large-10 columns">.large-10.columns</div>
+            <div className="large-2 columns">.large-2</div>
+            </div>
+            <div className="row">
+            <div className="large-12 columns">.large-12.columns</div>
+            </div>
+            <div className="row">
+            <div className="large-6 columns">.large-6.columns</div>
+            <div className="large-6 columns">.large-6.columns</div>
+            </div>
+            <div className="row">
+            <div className="large-4 columns">.large-4.columns</div>
+            <div className="large-4 columns">.large-4.columns</div>
+            <div className="large-4 columns">.large-4.columns</div>
+            </div>
+            <div className="row">
+            <div className="large-3 columns">.large-3.columns</div>
+            <div className="large-3 columns">.large-3.columns</div>
+            <div className="large-3 columns">.large-3.columns</div>
+            <div className="large-3 columns">.large-3.columns</div>
+            </div>
+            <div className="row">
+            <div className="large-2 columns">.large-2.columns</div>
+            <div className="large-2 columns">.large-2.columns</div>
+            <div className="large-2 columns">.large-2.columns</div>
+            <div className="large-2 columns">.large-2.columns</div>
+            <div className="large-2 columns">.large-2.columns</div>
+            <div className="large-2 columns">.large-2.columns</div>
+            </div>
+        </div>
         );
     }
 });

--- a/application/ui/scss/pattern-library/_pl-layout.scss
+++ b/application/ui/scss/pattern-library/_pl-layout.scss
@@ -61,9 +61,11 @@ $pl-header-height : rem-calc(64);
         height      : 60px;
         line-height : 60px;
     }
+
     &.example .row{
         margin-bottom : 20px;
     }
+
     &.example .row .column, &.example .row .columns{
         background : #e4e4e4;
         border     : 1px solid #ccc;

--- a/application/ui/scss/pattern-library/_pl-layout.scss
+++ b/application/ui/scss/pattern-library/_pl-layout.scss
@@ -53,31 +53,24 @@ $pl-header-height : rem-calc(64);
     margin      : $pl-header-height auto 0 auto;
     padding     : rem-calc(40);
 
-    .row {
-
-        &+ .pl-h2 {
-            margin-top: rem-calc(20);
-        }
-
-        &.display {
-            background: #eee;
-            font-size: 11px;
-            margin-bottom: 10px;
-            line-height: 2rem;
-            border: solid 1px #c6c6c6;
-            margin-left: 0 !important;
-            margin-right: 0 !important;
-            .columns:nth-child(2),
-            .columns.small-centered,
-            .columns.large-centered {
-                background: #e1e1e1;
-            }
-
-        }
-
+    &.example .row,
+    &.example .row .column,
+    &.example .row .columns {
+        font-size   : 11px;
+        background  : #f4f4f4;
+        height      : 60px;
+        line-height : 60px;
+    }
+    &.example .row{
+        margin-bottom : 20px;
+    }
+    &.example .row .column, &.example .row .columns{
+        background : #e4e4e4;
+        border     : 1px solid #ccc;
     }
 
 }
+
 
 // style guide page sidebar fixed to top
 // offset by sidebar on desktop


### PR DESCRIPTION
## Description
The Pattern Library's Grid doesn't look good in large browser sizes. It seems to render better when I shrink the window down to medium / small sizes, but when my browser is in full-screen, this is what I see:

![screen shot 2015-02-24 at 12 40 54 pm](https://cloud.githubusercontent.com/assets/5374685/6357531/66e4e924-bc22-11e4-8de4-cbb0833790a7.png)

## Details
http://localhost:9000/pattern-library/Grid