### PR TITLE
app_settings.scss is being overwritten by synfrastructure

### DIFF
--- a/application/ui/scss/_app_settings.scss
+++ b/application/ui/scss/_app_settings.scss
@@ -6,6 +6,8 @@
 // *******************************************
 // *******************************************
 
+@import "../../../node_modules/synfrastructure/scss/functions";
+
 $rem-base : 16px;
 
 // Font-size base

--- a/application/ui/scss/app.scss
+++ b/application/ui/scss/app.scss
@@ -1,8 +1,7 @@
 // vendor imports
     @import "vendor/reset";
-    @import "../../../node_modules/synfrastructure/scss/synfrastructure";
-
     @import "app_settings.scss";
+    @import "../../../node_modules/synfrastructure/scss/synfrastructure";
 
 // dependency imports
     @import "dependencies/colors";


### PR DESCRIPTION
### Acceptance Criteria
1. Changes to app_settings are interpreted by synfrastructure.

example: changing $row_width