### PR TITLE
Fix i18n for safari

### DIFF
--- a/application/bootstrap.js
+++ b/application/bootstrap.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict: true */
-/* globals window, Intl */
+/* globals window */
 'use strict';
 
 var React  = require('react');

--- a/application/bootstrap.js
+++ b/application/bootstrap.js
@@ -30,6 +30,10 @@ router.run(function (Handler, state) {
         locales = ['en-US'];
     }
 
+    if (locales.indexOf('en-US') === -1 && locales.indexOf('en-us') === -1) {
+        locales.push('en-US');
+    }
+
     React.render(
         React.createElement(Handler, {flux : flux, locales : locales, messages : i18n.messages}),
         window.document.body

--- a/application/ui/mixins/intlHelperMixin.js
+++ b/application/ui/mixins/intlHelperMixin.js
@@ -28,25 +28,6 @@ module.exports = {
             }
         }
 
-        // fix for Safari with single language
-        if (typeof navigator.languages !== 'undefined') {
-            // check to see if en-us is part of the languages array.  If not, check for an english string
-            if (navigator.languages.indexOf('en-us') === -1 && navigator.languages.indexOf('en-US') === -1) {
-                message = this._getTranslatedMessage('en-us', path);
-                if (message) {
-                    return message;
-                }
-            }
-        } else {
-            // if there's a language, use it, otherwise default to en-us
-            if (typeof navigator.language !== 'undefined' && navigator.language.toLowerCase() === 'en-us') {
-                message = this._getTranslatedMessage('en-us', path);
-                if (message) {
-                    return message;
-                }
-            }
-        }
-
         // if a message was not found, return the end of the path
         var pathParts = path.split('.');
         return pathParts[pathParts.length-1];

--- a/application/ui/mixins/intlHelperMixin.js
+++ b/application/ui/mixins/intlHelperMixin.js
@@ -31,7 +31,7 @@ module.exports = {
         // fix for Safari with single language
         if (typeof navigator.languages !== 'undefined') {
             // check to see if en-us is part of the languages array.  If not, check for an english string
-            if (!navigator.languages.indexOf('en-us') && !navigator.languages.indexOf('en-US')) {
+            if (navigator.languages.indexOf('en-us') === -1 && navigator.languages.indexOf('en-US') === -1) {
                 message = this._getTranslatedMessage('en-us', path);
                 if (message) {
                     return message;

--- a/application/ui/mixins/intlHelperMixin.js
+++ b/application/ui/mixins/intlHelperMixin.js
@@ -28,11 +28,22 @@ module.exports = {
             }
         }
 
-        // check to see if en-us is part of the languages array.  If not, check for an english string
-        if (!navigator.languages.indexOf('en-us') && !navigator.languages.indexOf('en-US')) {
-            message = this._getTranslatedMessage('en-us', path);
-            if (message) {
-                return message;
+        // fix for Safari with single language
+        if (typeof navigator.languages !== 'undefined') {
+            // check to see if en-us is part of the languages array.  If not, check for an english string
+            if (!navigator.languages.indexOf('en-us') && !navigator.languages.indexOf('en-US')) {
+                message = this._getTranslatedMessage('en-us', path);
+                if (message) {
+                    return message;
+                }
+            }
+        } else {
+            // if there's a language, use it, otherwise default to en-us
+            if (typeof navigator.language !== 'undefined' && navigator.language.toLowerCase() === 'en-us') {
+                message = this._getTranslatedMessage('en-us', path);
+                if (message) {
+                    return message;
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Safari, in its infinite wisdom, decided not to have `navigator.languages` if you only have a single language set.  In that case, there is only `navigator.language`.

## Acceptance Criteria
1. i18n works correctly in safari when only one language exists

## Details
