### PR TITLE
Dispatch Flux Actions After React Batched Updates

### DIFF
--- a/application/flux.js
+++ b/application/flux.js
@@ -1,8 +1,19 @@
-/* jshint globalstrict: true */
 'use strict';
 
-var Fluxxor = require('fluxxor');
-var stores  = require('./stores');
-var actions = require('./actions');
+var BatchedUpdates = require('react/lib/ReactUpdates').batchedUpdates;
+var Fluxxor        = require('fluxxor');
+var stores         = require('./stores');
+var actions        = require('./actions');
 
-module.exports = new Fluxxor.Flux(stores, actions);
+var dispatch, flux;
+
+flux     = new Fluxxor.Flux(stores, actions);
+dispatch = flux.dispatcher.dispatch.bind(flux.dispatcher);
+
+flux.dispatcher.dispatch = function(action) {
+    BatchedUpdates(function () {
+        dispatch(action);
+    });
+};
+
+module.exports = flux;

--- a/application/flux.js
+++ b/application/flux.js
@@ -1,9 +1,10 @@
+/* jshint globalstrict: true */
 'use strict';
 
-var BatchedUpdates = require('react/lib/ReactUpdates').batchedUpdates;
-var Fluxxor        = require('fluxxor');
-var stores         = require('./stores');
-var actions        = require('./actions');
+var Fluxxor      = require('fluxxor');
+var ReactUpdates = require('react/lib/ReactUpdates');
+var stores       = require('./stores');
+var actions      = require('./actions');
 
 var dispatch, flux;
 
@@ -11,7 +12,7 @@ flux     = new Fluxxor.Flux(stores, actions);
 dispatch = flux.dispatcher.dispatch.bind(flux.dispatcher);
 
 flux.dispatcher.dispatch = function(action) {
-    BatchedUpdates(function () {
+    ReactUpdates.batchedUpdates(function () {
         dispatch(action);
     });
 };


### PR DESCRIPTION
Fixes the ever present `cannot dispatch an action while another is being dispatched` issue.

The flux object should now be created by:

```javascript
/* jshint globalstrict: true */
'use strict';

var Fluxxor      = require('fluxxor');
var ReactUpdates = require('react/lib/ReactUpdates');
var stores       = require('./stores');
var actions      = require('./actions');

var dispatch, flux;

flux     = new Fluxxor.Flux(stores, actions);
dispatch = flux.dispatcher.dispatch.bind(flux.dispatcher);

flux.dispatcher.dispatch = function(action) {
    ReactUpdates.batchedUpdates(function () {
        dispatch(action);
    });
};

module.exports = flux;
``` 

### Acceptance Criteria
1. Use batched updated code to wait for react to finish its updates before dispatching another action
1. No more collisions in dispatching actions
1. No more using `setTimeout` hacks to dispatch actions

### Additional Notes
- Discussed here https://github.com/BinaryMuse/fluxxor/issues/92
- Implemented and tested in production here https://github.com/synapsestudios/researchaz.org/blob/develop/application/flux.js