### PR TITLE
Remove jshint pragmas

### DIFF
--- a/application/action/auth.js
+++ b/application/action/auth.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var constants   = require('../constants');

--- a/application/action/route.js
+++ b/application/action/route.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var router = require('../router');

--- a/application/actions.js
+++ b/application/actions.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var authActions  = require('./action/auth');

--- a/application/bootstrap.js
+++ b/application/bootstrap.js
@@ -1,5 +1,3 @@
-/* jshint globalstrict: true */
-/* globals window */
 'use strict';
 
 var React  = require('react');

--- a/application/client/oauth.js
+++ b/application/client/oauth.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var config      = require('../config');

--- a/application/client/user.js
+++ b/application/client/user.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var config      = require('../config');

--- a/application/config.js
+++ b/application/config.js
@@ -1,5 +1,3 @@
-/* jshint globalstrict: true */
-/* global __ENVIRONMENT__ */
 'use strict';
 
 // __ENVIRONMENT__ is replaced by gulp during build

--- a/application/config/ci.js
+++ b/application/config/ci.js
@@ -1,5 +1,3 @@
-/* jshint globalstrict: true */
-/* global __BACKEND__ */
 'use strict';
 
 var backend;

--- a/application/config/development.js
+++ b/application/config/development.js
@@ -1,5 +1,3 @@
-/* jshint globalstrict: true */
-/* global __BACKEND__ */
 'use strict';
 
 var backend;

--- a/application/config/production.js
+++ b/application/config/production.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 module.exports = {

--- a/application/config/qa.js
+++ b/application/config/qa.js
@@ -1,5 +1,3 @@
-/* jshint globalstrict: true */
-/* global __BACKEND__ */
 'use strict';
 
 var backend;

--- a/application/constants.js
+++ b/application/constants.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 module.exports = {

--- a/application/flux.js
+++ b/application/flux.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var Fluxxor = require('fluxxor');

--- a/application/intl/intl.js
+++ b/application/intl/intl.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 module.exports = {

--- a/application/router.jsx
+++ b/application/router.jsx
@@ -1,5 +1,4 @@
-/* jshint globalstrict: true, unused: false */
-/* globals __ENVIRONMENT__ */
+/* jshint unused: false */
 'use strict';
 
 var React    = require('react'); // Used in compiled js, so required even though appears unused

--- a/application/store/token.js
+++ b/application/store/token.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var constants = require('../constants');

--- a/application/store/user.js
+++ b/application/store/user.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var constants = require('../constants');

--- a/application/stores.js
+++ b/application/stores.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var TokenStore = require('./store/token');

--- a/application/ui/components/buttons/button.jsx
+++ b/application/ui/components/buttons/button.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/callouts-prompts/alerts.jsx
+++ b/application/ui/components/callouts-prompts/alerts.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React    = require('react');

--- a/application/ui/components/callouts-prompts/tooltip.jsx
+++ b/application/ui/components/callouts-prompts/tooltip.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React    = require('react');

--- a/application/ui/components/form/input-validation.jsx
+++ b/application/ui/components/form/input-validation.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React    = require('react');

--- a/application/ui/components/form/input.jsx
+++ b/application/ui/components/form/input.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/form/inputs/checkbox-group.jsx
+++ b/application/ui/components/form/inputs/checkbox-group.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/components/form/inputs/checkbox.jsx
+++ b/application/ui/components/form/inputs/checkbox.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/form/inputs/form-inputs-mixin.js
+++ b/application/ui/components/form/inputs/form-inputs-mixin.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 module.exports = {

--- a/application/ui/components/form/inputs/radio-group.jsx
+++ b/application/ui/components/form/inputs/radio-group.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/components/form/inputs/radio.jsx
+++ b/application/ui/components/form/inputs/radio.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/form/inputs/select.jsx
+++ b/application/ui/components/form/inputs/select.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/components/form/inputs/switch.jsx
+++ b/application/ui/components/form/inputs/switch.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/form/inputs/text.jsx
+++ b/application/ui/components/form/inputs/text.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/components/form/inputs/textarea.jsx
+++ b/application/ui/components/form/inputs/textarea.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/components/form/label.jsx
+++ b/application/ui/components/form/label.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React    = require('react');

--- a/application/ui/components/icon/icon.jsx
+++ b/application/ui/components/icon/icon.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/icon/icons/back.jsx
+++ b/application/ui/components/icon/icons/back.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/icon/icons/cancel.jsx
+++ b/application/ui/components/icon/icons/cancel.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/icon/icons/caret.jsx
+++ b/application/ui/components/icon/icons/caret.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/icon/icons/group.jsx
+++ b/application/ui/components/icon/icons/group.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/icon/icons/heart.jsx
+++ b/application/ui/components/icon/icons/heart.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/icon/icons/save.jsx
+++ b/application/ui/components/icon/icons/save.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/icon/icons/search.jsx
+++ b/application/ui/components/icon/icons/search.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/icon/icons/trash.jsx
+++ b/application/ui/components/icon/icons/trash.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/navigation/pagination-item.jsx
+++ b/application/ui/components/navigation/pagination-item.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React    = require('react');

--- a/application/ui/components/navigation/pagination.jsx
+++ b/application/ui/components/navigation/pagination.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/pattern-library/pl-nav-item.jsx
+++ b/application/ui/components/pattern-library/pl-nav-item.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React     = require('react');

--- a/application/ui/components/pattern-library/pl-sidebar.jsx
+++ b/application/ui/components/pattern-library/pl-sidebar.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React     = require('react');

--- a/application/ui/components/pattern-library/sections/pl-buttons.jsx
+++ b/application/ui/components/pattern-library/sections/pl-buttons.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/components/pattern-library/sections/pl-callouts-prompts.jsx
+++ b/application/ui/components/pattern-library/sections/pl-callouts-prompts.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React   = require('react');

--- a/application/ui/components/pattern-library/sections/pl-form-elements.jsx
+++ b/application/ui/components/pattern-library/sections/pl-form-elements.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/components/pattern-library/sections/pl-grid.jsx
+++ b/application/ui/components/pattern-library/sections/pl-grid.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/pattern-library/sections/pl-icons.jsx
+++ b/application/ui/components/pattern-library/sections/pl-icons.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/components/pattern-library/sections/pl-navigation.jsx
+++ b/application/ui/components/pattern-library/sections/pl-navigation.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React          = require('react');

--- a/application/ui/components/pattern-library/sections/pl-typography.jsx
+++ b/application/ui/components/pattern-library/sections/pl-typography.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React  = require('react');

--- a/application/ui/components/tabs/tab-nav-item.jsx
+++ b/application/ui/components/tabs/tab-nav-item.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React    = require('react');

--- a/application/ui/components/tabs/tab-nav.jsx
+++ b/application/ui/components/tabs/tab-nav.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React    = require('react');

--- a/application/ui/mixins/intlHelperMixin.js
+++ b/application/ui/mixins/intlHelperMixin.js
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 /* global navigator */
 'use strict';
 

--- a/application/ui/pages/404.jsx
+++ b/application/ui/pages/404.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/pages/formatting.jsx
+++ b/application/ui/pages/formatting.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/pages/home.jsx
+++ b/application/ui/pages/home.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/pages/pattern-library.jsx
+++ b/application/ui/pages/pattern-library.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React            = require('react');

--- a/application/ui/regions/header/user-logged-in.jsx
+++ b/application/ui/regions/header/user-logged-in.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/application/ui/regions/header/user-logged-out.jsx
+++ b/application/ui/regions/header/user-logged-out.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React = require('react');

--- a/application/ui/site.jsx
+++ b/application/ui/site.jsx
@@ -1,4 +1,3 @@
-/* jshint globalstrict: true */
 'use strict';
 
 var React           = require('react');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,4 +88,13 @@ module.exports = {
         extensions : ['', '.css', '.js', '.json', '.jsx', '.scss', '.webpack.js', '.web.js']
     },
     devtool : '#inline-source-map',
+    jshint  : {
+        globalstrict : true,
+        globals      : {
+            __BACKEND__     : true,
+            __ENVIRONMENT__ : true,
+            console         : true,
+            window          : true
+        }
+    }
 };


### PR DESCRIPTION
## Webpack can insert jshint pragmas automatically for us so we don't to include them in every file

### Acceptance Criteria
1. `globalstrict: true` set by webpack
1. `global __ENVIRONMENT__, __BACKEND__, console, window` is set by webpack
