### PR TITLE
Fix undefined backend hostname issue and remove source maps and dev dependencies from production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "start"   : "rm -rf ./build && webpack && node dev-server",
         "windows" : "rmdir /S /Q build && webpack.cmd && node dev-server",
         "webpack" : "rm -rf ./build && webpack",
-        "dist"    : "rm -rf ./build && APP_ENV=production webpack -p && zip -r build-`date +%s` application build node_modules server server.js",
+        "dist"    : "rm -rf ./build && APP_ENV=production webpack -p && zip -r build-`date +%s` build",
         "test"    : "cd __tests__ && rm -rf ./build && webpack && node dev-server",
         "karma"   : "./node_modules/karma/bin/karma start karma.conf.js",
         "clean"   : "rm -rf ./build"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,11 +7,12 @@ var path              = require('path');
 var environment = (process.env.APP_ENV || 'development');
 var npmPath     = path.resolve(__dirname, 'node_modules');
 var config      = {
-    entry   : ['./application/bootstrap.js'],
-    plugins : [
+    devtools : [],
+    entry    : ['./application/bootstrap.js'],
+    plugins  : [
         new HtmlWebpack({template : './application/index.html'}),
         new Webpack.DefinePlugin({
-            __BACKEND__     : '\'' + process.env.BACKEND + '\'',
+            __BACKEND__     : process.env.BACKEND ? '\'' + process.env.BACKEND + '\'' : undefined,
             __ENVIRONMENT__ : '\'' + environment + '\''
         })
     ],
@@ -35,6 +36,10 @@ if (environment === 'development') {
     if (process.platform !== 'win32') {
         config.plugins.push(new WebpackError(process.platform));
     }
+}
+
+if (environment !== 'production') {
+    config.devtools = '#inline-source-map';
 }
 
 module.exports = {
@@ -87,7 +92,7 @@ module.exports = {
     resolve : {
         extensions : ['', '.css', '.js', '.json', '.jsx', '.scss', '.webpack.js', '.web.js']
     },
-    devtool : '#inline-source-map',
+    devtool : config.devtools,
     jshint  : {
         globalstrict : true,
         globals      : {


### PR DESCRIPTION
Hostnames, if not explicitly specified, evaluate to `"undefined"` rather than `undefined`.

Source maps and dev dependencies are still included in prod builds and make a ~0.9MB build into a 10MB build.

This patch fixes both issues.