### PR TITLE
Remove Image Loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "extract-text-webpack-plugin" : "0.5.0",
     "file-loader"                 : "0.8.1",
     "html-webpack-plugin"         : "1.1.0",
-    "image-webpack-loader"        : "1.2.0",
     "json-loader"                 : "0.5.1",
     "jshint-loader"               : "0.8.1",
     "jsx-loader"                  : "0.11.2",

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 rm -rf build
-rm -f server/render-generated.js
 
 pm2 delete all > /dev/null 2>&1
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = [
             ],
             loaders : [
                 {
-                    test   : /\.(eot|ico|ttf|woff|woff2)$/,
+                    test   : /\.(eot|ico|ttf|woff|woff2|gif|jpe?g|png|svg)$/,
                     loader : 'file-loader'
                 },
                 {
@@ -75,10 +75,6 @@ module.exports = [
                 {
                     test   : /\.scss$/,
                     loader : 'style!css!autoprefixer!sass' + config.sassOptions
-                },
-                {
-                    test    : /\.(gif|jpe?g|png|svg)$/i,
-                    loaders : ['image?bypassOnDebug&optimizationLevel=7&interlaced=false&progressive=true']
                 }
             ]
         },

--- a/webpack.server.js
+++ b/webpack.server.js
@@ -8,7 +8,7 @@ var exec              = require('child_process').exec;
 var environment = (process.env.APP_ENV || 'development');
 var npmPath     = path.resolve(__dirname, 'node_modules');
 var config      = {
-    nodeModules : {},
+    externals : {},
     plugins     : [
         new ExtractTextPlugin('app.css', {allChunks : true}),
         new Webpack.DefinePlugin({
@@ -37,7 +37,7 @@ fs.readdirSync('node_modules')
     )
     .forEach(
         function (mod) {
-            config.nodeModules[mod] = 'commonjs ' + mod;
+            config.externals[mod] = 'commonjs ' + mod;
         }
     );
 
@@ -77,7 +77,7 @@ module.exports = [
             ],
             loaders : [
                 {
-                    test   : /\.(eot|ico|ttf|woff|woff2)$/,
+                    test   : /\.(eot|ico|ttf|woff|woff2|gif|jpe?g|png|svg)$/,
                     loader : 'file-loader'
                 },
                 {
@@ -95,14 +95,10 @@ module.exports = [
                         'style-loader',
                         'css-loader!sass-loader' + config.sassOptions
                     )
-                },
-                {
-                    test    : /\.(gif|jpe?g|png|svg)$/i,
-                    loaders : [require.resolve('image-webpack-loader') + '?bypassOnDebug&optimizationLevel=7&interlaced=false&progressive=true']
                 }
             ]
         },
-        externals : config.nodeModules,
+        externals : config.externals,
         plugins   : config.plugins,
         resolve   : {
             extensions : ['', '.css', '.js', '.json', '.jsx', '.scss', '.webpack.js', '.web.js']


### PR DESCRIPTION
Image loader adds a massive dependency and a ton of overhead to our builds. I think we can get by with un-optimized images. Any optimization can take place before the image is added to the repo.

### Acceptance Criteria
1. Images are loaded with file-loader
1. image-webpack-loader is gone forever