### PR TITLE
Update Flux Pass Parameters to Stores

### DIFF
--- a/application/flux.js
+++ b/application/flux.js
@@ -11,7 +11,11 @@ var Flux = function () {
     var stores = {};
 
     _.each(Stores, function (Store, name) {
-        stores[name] = new Store();
+        if (_.isArray(Store)) {
+            stores[name] = new Store[0](Store[1]);
+        } else {
+            stores[name] = new Store();
+        }
     });
 
     Fluxxor.Flux.call(this, stores, actions);


### PR DESCRIPTION
## Flux is able to pass parameters to stores as they are initialized

### Acceptance Criteria
1. `applications/stores.js` can define a store as either a class or an array of a class and parameters
1. If just a class is passed it is initialized with no parameters
1. If an array is passed then the first element is assumed to be the class and any other elements are assumed to be the parameters

This example is how the matchMedia store can be initialized with queries and a default true query
```
var MatchMedia = require('synapse-common/store/match-media');

var Token = require('./store/token');
var User  = require('./store/user');

var params = {
    queries : {
        upToSmall  : '(max-width: 30em)', // up to 480px
        upToMedium : '(max-width: 48em)', // up to 768px
        upToLarge  : '(max-width: 64em)', // up to 1024px
        upToXLarge : '(max-width: 90em)' // up to 1440px
    },
    default : 'upToLarge'
};

module.exports = {
    MatchMedia : [MatchMedia, params],
    Token      : Token,
    User       : User
};
```
