### PR TITLE
Set hostname via environment varible

### DIFF
--- a/application/config.js
+++ b/application/config.js
@@ -7,7 +7,7 @@ var defaults, config;
 defaults = {
     api : {
         client_id : '123',
-        hostname  : 'localhost',
+        hostname  : __HOSTNAME__,
         oauth     : {
             login : '/oauth/login',
             token : '/oauth/token'

--- a/dev-server.js
+++ b/dev-server.js
@@ -1,5 +1,6 @@
 global.__BACKEND__     = process.env.BACKEND;
 global.__ENVIRONMENT__ = process.env.APP_ENV || 'development';
+global.__HOSTNAME__    = process.env.HOST || 'localhost';
 
 var path             = require('path');
 var request          = require('request');

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 global.__BACKEND__     = process.env.BACKEND || '';
 global.__ENVIRONMENT__ = process.env.APP_ENV || 'development';
+global.__HOSTNAME__    = process.env.HOST || 'localhost';
 global.localStorage    = require('localStorage');
 global.navigator       = require('navigator');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+var __HOSTNAME__ = process.env.HOST ? process.env.HOST : 'localhost';
+
 var Webpack           = require('webpack');
 var WebpackError      = require('webpack-error-notification');
 var path              = require('path');
@@ -11,7 +13,7 @@ var config      = {
         new Webpack.DefinePlugin({
             __BACKEND__     : process.env.BACKEND ? '\'' + process.env.BACKEND + '\'' : undefined,
             __ENVIRONMENT__ : '\'' + environment + '\'',
-            __HOSTNAME__    : process.env.HOST ? '\'' + process.env.HOST + '\'' : '\'localhost\'',
+            __HOSTNAME__    : '\'' + __HOSTNAME__ + '\'',
             "process.env"   : {
                 NODE_ENV : '\'' + environment + '\''
             }
@@ -28,7 +30,7 @@ if (environment !== 'production') {
     config.devtools = '#inline-source-map';
     config.entry = [
         'webpack/hot/dev-server',
-        'webpack-dev-server/client?http://localhost:9000'
+        'webpack-dev-server/client?http://' + __HOSTNAME__ + ':9000'
     ].concat(config.entry);
 
     config.reactLoaders = ['react-hot'].concat(config.reactLoaders);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ var config      = {
         new Webpack.DefinePlugin({
             __BACKEND__     : process.env.BACKEND ? '\'' + process.env.BACKEND + '\'' : undefined,
             __ENVIRONMENT__ : '\'' + environment + '\'',
+            __HOSTNAME__    : process.env.HOST ? '\'' + process.env.HOST + '\'' : '\'localhost\'',
             "process.env"   : {
                 NODE_ENV : '\'' + environment + '\''
             }
@@ -91,6 +92,7 @@ module.exports = [
             globals      : {
                 __BACKEND__     : true,
                 __ENVIRONMENT__ : true,
+                __HOSTNAME__    : true,
                 console         : true,
                 window          : true,
                 setTimeout      : true
@@ -118,6 +120,7 @@ module.exports = [
             globals      : {
                 __BACKEND__     : true,
                 __ENVIRONMENT__ : true,
+                __HOSTNAME__    : true,
                 console         : true,
                 window          : true,
                 setTimeout      : true

--- a/webpack.server.js
+++ b/webpack.server.js
@@ -13,7 +13,8 @@ var config      = {
         new ExtractTextPlugin('app.css', {allChunks : true}),
         new Webpack.DefinePlugin({
             __BACKEND__     : process.env.BACKEND ? '\'' + process.env.BACKEND + '\'' : undefined,
-            __ENVIRONMENT__ : '\'' + environment + '\''
+            __ENVIRONMENT__ : '\'' + environment + '\'',
+            __HOSTNAME__    : process.env.HOST ? '\'' + process.env.HOST + '\'' : '\'localhost\''
         }),
         function () {
             this.plugin('done', function () {
@@ -108,6 +109,7 @@ module.exports = [
             globals      : {
                 __BACKEND__     : true,
                 __ENVIRONMENT__ : true,
+                __HOSTNAME__    : true,
                 console         : true,
                 localStorage    : true,
                 navigator       : true,

--- a/webpack.server.js
+++ b/webpack.server.js
@@ -1,3 +1,5 @@
+var __HOSTNAME__ = process.env.HOST ? process.env.HOST : 'localhost';
+
 var Webpack           = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var WebpackError      = require('webpack-error-notification');
@@ -14,7 +16,7 @@ var config      = {
         new Webpack.DefinePlugin({
             __BACKEND__     : process.env.BACKEND ? '\'' + process.env.BACKEND + '\'' : undefined,
             __ENVIRONMENT__ : '\'' + environment + '\'',
-            __HOSTNAME__    : process.env.HOST ? '\'' + process.env.HOST + '\'' : '\'localhost\''
+            __HOSTNAME__    : '\'' + __HOSTNAME__ + '\''
         }),
         function () {
             this.plugin('done', function () {
@@ -45,7 +47,7 @@ fs.readdirSync('node_modules')
 if (environment !== 'production') {
     config.entry = [
         'webpack/hot/dev-server',
-        'webpack-dev-server/client?http://localhost:9000'
+        'webpack-dev-server/client?http://' + __HOSTNAME__ + ':9000'
     ].concat(config.entry);
 
     if (process.platform !== 'win32') {


### PR DESCRIPTION
## To facilitate IE testing via internal IP addresses we need to tell the bundle to request from that IP address, not localhost

### Acceptance Criteria
1. The hostname can be passed with an environment variable `HOST=192.168.2.x npm start`
1. This hostname will be used for requests instead of localhost