### PR TITLE
remove media bundle, optimize webpack

### DIFF
--- a/application/bootstrap.js
+++ b/application/bootstrap.js
@@ -11,6 +11,7 @@ import { addResponsiveHandlers } from 'redux-responsive';
 
 window.React = React;
 
+import './ui/scss/app';
 import app from './redux/reducers';
 
 /**************************************************************************

--- a/application/media.js
+++ b/application/media.js
@@ -1,7 +1,0 @@
-import './ui/scss/app';
-
-import '!file-loader?name=[path][name].[ext]!../static-media/icons/favicon.png';
-import '!file-loader?name=[path][name].[ext]!../static-media/icons/apple-touch-icon-60x60.png';
-import '!file-loader?name=[path][name].[ext]!../static-media/icons/apple-touch-icon-76x76.png';
-import '!file-loader?name=[path][name].[ext]!../static-media/icons/apple-touch-icon-60x60@2x.png';
-import '!file-loader?name=[path][name].[ext]!../static-media/icons/apple-touch-icon-76x76@2x.png';

--- a/dev-server.js
+++ b/dev-server.js
@@ -2,31 +2,29 @@ global.__BACKEND__     = process.env.BACKEND;
 global.__ENVIRONMENT__ = process.env.APP_ENV || 'development';
 global.__HOSTNAME__    = process.env.HOST || 'localhost';
 
-var path      = require('path');
-var request   = require('request');
-var webpack   = require('webpack');
-var appConfig = require('./application/config');
-var config    = require('./webpack.config');
-var proxy     = require('express-http-proxy');
-var express   = require('express');
+var path          = require('path');
+var request       = require('request');
+var webpack       = require('webpack');
+var appConfig     = require('./application/config');
+var webpackConfig = require('./webpack.config');
+var proxy         = require('express-http-proxy');
+var express       = require('express');
 
-var app           = express();
-var appCompiler   = webpack(config[0]);
-var mediaCompiler = webpack(config[1]);
+var app        = express();
+var compiler   = webpack(webpackConfig);
+var publicPath = webpackConfig.output.publicPath;
 
-app.use(require('webpack-dev-middleware')(appCompiler, {
+app.use(require('webpack-dev-middleware')(compiler, {
+    publicPath : publicPath,
     contentBase : path.resolve(__dirname, 'build'),
+    hot: true,
+    quiet: true,
     noInfo: true,
-    publicPath: '/'
+    lazy: false,
+    stats: true
 }));
-app.use(require('webpack-hot-middleware')(appCompiler));
 
-app.use(require('webpack-dev-middleware')(mediaCompiler, {
-    contentBase : path.resolve(__dirname, 'build'),
-    noInfo: true,
-    publicPath: '/'
-}));
-app.use(require('webpack-hot-middleware')(mediaCompiler));
+app.use(require('webpack-hot-middleware')(compiler));
 
 if (! appConfig.api.prefix) {
     throw new Error('API prefix not set in configuration');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,19 +1,18 @@
 var __HOSTNAME__ = process.env.HOST ? process.env.HOST : 'localhost';
 
-var autoprefixer = require('autoprefixer');
-var webpack      = require('webpack');
-var WebpackError = require('webpack-error-notification');
-var path         = require('path');
-var htmlWebpack  = require('html-webpack-plugin');
+var autoprefixer      = require('autoprefixer');
+var webpack           = require('webpack');
+var WebpackError      = require('webpack-error-notification');
+var path              = require('path');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 var environment = (process.env.APP_ENV || 'development');
 var npmPath     = path.resolve(__dirname, 'node_modules');
 var config      = {
     devtools : [],
-    entries  : {
-        app   : ['./application/bootstrap.js'],
-        media : ['./application/media.js']
-    },
+    entry    : environment !== 'production'
+        ? ['./application/bootstrap.js', 'webpack-hot-middleware/client?path=/__webpack_hmr?http://' + __HOSTNAME__ + ':9000']
+        : ['./application/bootstrap.js'],
     plugins  : [
         new webpack.DefinePlugin({
             __BACKEND__     : process.env.BACKEND ? '\'' + process.env.BACKEND + '\'' : undefined,
@@ -23,8 +22,9 @@ var config      = {
                 NODE_ENV : '\'' + environment + '\''
             }
         }),
-        new htmlWebpack({template : './application/index.html'}),
-        new webpack.NoErrorsPlugin()
+        new webpack.optimize.OccurrenceOrderPlugin(),
+        new webpack.optimize.DedupePlugin(),
+        new HtmlWebpackPlugin({template : './application/index.html'})
     ],
     sassOptions  : (
         '?outputStyle=' + (environment === 'production' ? 'compressed' : 'nested') +
@@ -33,94 +33,61 @@ var config      = {
 };
 
 if (environment !== 'production') {
-    config.devtools = '#inline-source-map';
-    config.entries.app.unshift('webpack-hot-middleware/client?http://' + __HOSTNAME__ + ':9000');
-    config.entries.media.unshift('webpack-hot-middleware/client?http://' + __HOSTNAME__ + ':9000');
-    config.plugins.push(new webpack.HotModuleReplacementPlugin());
+    config.devtools = 'eval-source-map';
+    config.plugins.push(
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.NoErrorsPlugin()
+    );
 
     if (process.platform !== 'win32') {
         config.plugins.push(new WebpackError(process.platform));
     }
 }
 
-module.exports = [
-    {
-        name   : 'app bundle',
-        entry: config.entries.app,
-        output : {
-            filename   : 'app.js',
-            path       : path.resolve(__dirname, 'build'),
-            publicPath : '/'
-        },
-        module: {
-            preLoaders : [
-                {
-                    test    : /\.jsx?$/,
-                    loader  : 'eslint-loader',
-                    exclude : npmPath
-                }
-            ],
-            loaders : [
-                {
-                    test   : /\.(eot|ico|ttf|woff|woff2|gif|jpe?g|png|svg)$/,
-                    loader : 'file-loader'
-                },
-                {
-                    test    : /\.jsx?$/,
-                    loaders : ['babel'],
-                    exclude : npmPath
-                },
-                {
-                    test   : /\.json$/,
-                    loader : 'json-loader'
-                },
-                {
-                    test   : /\.scss$/,
-                    loader : 'style!css!postcss!sass' + config.sassOptions
-                }
-            ]
-        },
-        plugins : config.plugins,
-        postcss : function() {
-            return [autoprefixer];
-        },
-        resolve : {
-            extensions : ['', '.css', '.js', '.json', '.jsx', '.scss', '.webpack.js', '.web.js']
-        },
-        devtool : config.devtools
+module.exports = {
+    name   : 'app bundle',
+    entry  : config.entry,
+    output : {
+        filename   : 'app.js',
+        path       : path.resolve(__dirname, 'build'),
+        publicPath : '/'
     },
-    {
-        name   : 'media bundle',
-        entry  : config.entries.media,
-        output : {
-            filename   : 'media.js',
-            path       : path.resolve(__dirname, 'build'),
-            publicPath : '/'
-        },
-        module : {
-            loaders : [
-                {
-                    test   : /\.(eot|ico|ttf|woff|woff2|gif|jpe?g|png|svg)$/,
-                    loader : 'file-loader'
-                },
-                {
-                    test    : /\.jsx?$/,
-                    loaders : ['babel'],
-                    exclude : npmPath
-                },
-                {
-                    test   : /\.scss$/,
-                    loader : 'style!css!postcss!sass' + config.sassOptions
-                }
-            ]
-        },
-        plugins : config.plugins,
-        postcss : function() {
-            return [autoprefixer];
-        },
-        resolve : {
-            extensions : ['', '.css', '.js', '.scss', '.webpack.js', '.web.js']
-        },
-        devtool : config.devtools
-    }
-];
+    module: {
+        preLoaders : [
+            {
+                test    : /\.jsx?$/,
+                loader  : 'eslint-loader',
+                exclude : npmPath
+            }
+        ],
+        loaders : [
+            {
+                test   : /\.(eot|ico|ttf|woff|woff2|gif|jpe?g|png|svg)$/,
+                loader : 'file-loader',
+                exclude : npmPath
+            },
+            {
+                test    : /\.jsx?$/,
+                loaders : ['babel'],
+                exclude : npmPath
+            },
+            {
+                test   : /\.json$/,
+                loader : 'json-loader',
+                exclude : npmPath
+            },
+            {
+                test   : /\.scss$/,
+                loader : 'style!css!postcss!sass' + config.sassOptions
+            }
+        ]
+    },
+    plugins : config.plugins,
+    postcss : function() {
+        return [autoprefixer];
+    },
+    resolve : {
+        extensions : ['', '.css', '.js', '.json', '.jsx', '.scss', '.webpack.js', '.web.js']
+    },
+    devtool : config.devtools
+};


### PR DESCRIPTION
- Webpack wasn't happy about having multiple instances, and threw errors
- Media bundle wasn't being reloaded
- Uses `eval-source-map` to speed up compiles, if this is an issue we can use `cheap-source-map`
- Optimization plugins - https://github.com/webpack/docs/wiki/optimization